### PR TITLE
SIGSEGV Crash on Linux (GLX) due to Native Symbol Collision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 /.gradle/
 /build/
 /.idea/
+
+# Gradle build outputs
+/modules/*/build/
+/modules/*/native/build/
+
+/plugins/*/.gradle/
+/plugins/*/build/

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2.3.13
+version=2.3.14
 
 kotlin.code.style=official
 

--- a/modules/gl/native/linux/egl/gl-linux-egl-context.cpp
+++ b/modules/gl/native/linux/egl/gl-linux-egl-context.cpp
@@ -17,7 +17,7 @@ eglSwapBuffersPtr         eglSwapBuffers;
 eglSwapIntervalPtr        eglSwapInterval;
 
 glGetIntegervPtr          _glGetIntegerv;
-glGetStringiPtr           _glGetStringi;
+glGetStringiPtr           glGetStringi;
 glDebugMessageCallbackARBPtr _glDebugMessageCallbackARB;
 
 
@@ -57,7 +57,7 @@ jni_linux_egl_context(void, nInitFunctions)(JNIEnv* env, jobject) {
 
     _glDebugMessageCallbackARB = (glDebugMessageCallbackARBPtr)eglGetProcAddress("_glDebugMessageCallbackARB");
     _glGetIntegerv = (glGetIntegervPtr)eglGetProcAddress("_glGetIntegerv");
-    _glGetStringi = (glGetStringiPtr)eglGetProcAddress("_glGetStringi");
+    glGetStringi = (glGetStringiPtr)eglGetProcAddress("glGetStringi");
 }
 
 jni_linux_egl_context(jlongArray, nCreateContext)(JNIEnv* env, jobject, jboolean isCore, jlong shareWith, jint majorVersion, jint minorVersion, jboolean debug) {

--- a/modules/gl/native/linux/egl/gl-linux-egl-context.cpp
+++ b/modules/gl/native/linux/egl/gl-linux-egl-context.cpp
@@ -16,9 +16,9 @@ eglDestroyContextPtr      eglDestroyContext;
 eglSwapBuffersPtr         eglSwapBuffers;
 eglSwapIntervalPtr        eglSwapInterval;
 
-glGetIntegervPtr          glGetIntegerv;
-glGetStringiPtr           glGetStringi;
-glDebugMessageCallbackARBPtr glDebugMessageCallbackARB;
+glGetIntegervPtr          _glGetIntegerv;
+glGetStringiPtr           _glGetStringi;
+glDebugMessageCallbackARBPtr _glDebugMessageCallbackARB;
 
 
 static void getContextDetailsEGL(GLDetails* details, EGLDisplay display, EGLSurface surfaceRead, EGLSurface surfaceWrite, EGLContext context){
@@ -55,9 +55,9 @@ jni_linux_egl_context(void, nInitFunctions)(JNIEnv* env, jobject) {
     eglSwapBuffers = (eglSwapBuffersPtr)eglGetProcAddress("eglSwapBuffers");
     eglSwapInterval = (eglSwapIntervalPtr)eglGetProcAddress("eglSwapInterval");
 
-    glDebugMessageCallbackARB = (glDebugMessageCallbackARBPtr)eglGetProcAddress("glDebugMessageCallbackARB");
-    glGetIntegerv = (glGetIntegervPtr)eglGetProcAddress("glGetIntegerv");
-    glGetStringi = (glGetStringiPtr)eglGetProcAddress("glGetStringi");
+    _glDebugMessageCallbackARB = (glDebugMessageCallbackARBPtr)eglGetProcAddress("_glDebugMessageCallbackARB");
+    _glGetIntegerv = (glGetIntegervPtr)eglGetProcAddress("_glGetIntegerv");
+    _glGetStringi = (glGetStringiPtr)eglGetProcAddress("_glGetStringi");
 }
 
 jni_linux_egl_context(jlongArray, nCreateContext)(JNIEnv* env, jobject, jboolean isCore, jlong shareWith, jint majorVersion, jint minorVersion, jboolean debug) {

--- a/modules/gl/native/linux/glx/gl-linux-glx-context.cpp
+++ b/modules/gl/native/linux/glx/gl-linux-glx-context.cpp
@@ -25,7 +25,7 @@ jni_linux_glx_context(void, nInitFunctions)(JNIEnv* env, jobject) {
 
     _glDebugMessageCallbackARB = (glDebugMessageCallbackARBPtr)_GetProcAddress("glDebugMessageCallbackARB");
     _glGetIntegerv = (glGetIntegervPtr)_GetProcAddress("glGetIntegerv");
-    _glGetStringi = (glGetStringiPtr)_GetProcAddress("glGetStringi");
+    glGetStringi = (glGetStringiPtr)_GetProcAddress("glGetStringi");
 }
 
 jni_linux_glx_context(jlongArray, nCreateContext)(JNIEnv* env, jobject, jboolean isCore, jlong shareWith, jint majorVersion, jint minorVersion, jboolean debug) {

--- a/modules/gl/native/linux/glx/gl-linux-glx-context.cpp
+++ b/modules/gl/native/linux/glx/gl-linux-glx-context.cpp
@@ -1,9 +1,9 @@
 #include "gl-linux-glx.h"
 
-glXCreateContextAttribsARBPtr glXCreateContextAttribsARB = NULL;
-glXSwapIntervalEXTPtr         glXSwapIntervalEXT = NULL;
-glXSwapIntervalMESAPtr        glXSwapIntervalMESA = NULL;
-glXSwapIntervalMESAPtr        glXSwapIntervalSGI = NULL;
+glXCreateContextAttribsARBPtr _glXCreateContextAttribsARB = NULL;
+glXSwapIntervalEXTPtr         _glXSwapIntervalEXT = NULL;
+glXSwapIntervalMESAPtr        _glXSwapIntervalMESA = NULL;
+glXSwapIntervalMESAPtr        _glXSwapIntervalSGI = NULL;
 
 
 static void getContextDetailsGLX(GLDetails* details, Display* display, GLXDrawable drawable, GLXContext context){
@@ -18,14 +18,14 @@ static void getContextDetailsGLX(GLDetails* details, Display* display, GLXDrawab
 
 
 jni_linux_glx_context(void, nInitFunctions)(JNIEnv* env, jobject) {
-    glXCreateContextAttribsARB = (glXCreateContextAttribsARBPtr)_GetProcAddress("glXCreateContextAttribsARB");
-    glXSwapIntervalEXT = (glXSwapIntervalEXTPtr)_GetProcAddress("glXSwapIntervalEXT");
-    glXSwapIntervalMESA = (glXSwapIntervalMESAPtr)_GetProcAddress("glXSwapIntervalMESA");
-    glXSwapIntervalSGI = (glXSwapIntervalMESAPtr)_GetProcAddress("glXSwapIntervalSGI");
+    _glXCreateContextAttribsARB = (glXCreateContextAttribsARBPtr)_GetProcAddress("glXCreateContextAttribsARB");
+    _glXSwapIntervalEXT = (glXSwapIntervalEXTPtr)_GetProcAddress("glXSwapIntervalEXT");
+    _glXSwapIntervalMESA = (glXSwapIntervalMESAPtr)_GetProcAddress("glXSwapIntervalMESA");
+    _glXSwapIntervalSGI = (glXSwapIntervalMESAPtr)_GetProcAddress("glXSwapIntervalSGI");
 
-    glDebugMessageCallbackARB = (glDebugMessageCallbackARBPtr)_GetProcAddress("glDebugMessageCallbackARB");
-    glGetIntegerv = (glGetIntegervPtr)_GetProcAddress("glGetIntegerv");
-    glGetStringi = (glGetStringiPtr)_GetProcAddress("glGetStringi");
+    _glDebugMessageCallbackARB = (glDebugMessageCallbackARBPtr)_GetProcAddress("glDebugMessageCallbackARB");
+    _glGetIntegerv = (glGetIntegervPtr)_GetProcAddress("glGetIntegerv");
+    _glGetStringi = (glGetStringiPtr)_GetProcAddress("glGetStringi");
 }
 
 jni_linux_glx_context(jlongArray, nCreateContext)(JNIEnv* env, jobject, jboolean isCore, jlong shareWith, jint majorVersion, jint minorVersion, jboolean debug) {
@@ -43,7 +43,7 @@ jni_linux_glx_context(jlongArray, nCreateContext)(JNIEnv* env, jobject, jboolean
             GLX_CONTEXT_FLAGS_ARB, debug ? GLX_CONTEXT_DEBUG_BIT_ARB : 0,
             None
     };
-    GLXContext context = glXCreateContextAttribsARB(display, fbc[0], (GLXContext)shareWith, true, context_attribs);
+    GLXContext context = _glXCreateContextAttribsARB(display, fbc[0], (GLXContext)shareWith, true, context_attribs);
 
     // Creating PBuffer
     int pbufferAttribs[] = {
@@ -121,7 +121,7 @@ jni_linux_glx_context(jlongArray, nCreateContextForWindow)(JNIEnv* env, jobject,
             GLX_CONTEXT_FLAGS_ARB, debug ? GLX_CONTEXT_DEBUG_BIT_ARB : 0,
             None
     };
-    GLXContext context = glXCreateContextAttribsARB(display, fbc[0], (GLXContext)shareWith, true, context_attribs);
+    GLXContext context = _glXCreateContextAttribsARB(display, fbc[0], (GLXContext)shareWith, true, context_attribs);
 
     GLDetails details = {};
     getContextDetailsGLX(&details, display, window, context);

--- a/modules/gl/native/linux/glx/gl-linux-glx-manager.cpp
+++ b/modules/gl/native/linux/glx/gl-linux-glx-manager.cpp
@@ -13,10 +13,10 @@ jni_linux_glx_manager(void, nSetSwapInterval)(JNIEnv* env, jobject, jlong _displ
     Display* display = (Display*)_display;
     Window window = (Window)_window;
 
-    if (glXSwapIntervalEXT)
-        glXSwapIntervalEXT(display, window, swapInterval);
-    else if(glXSwapIntervalMESA)
-        glXSwapIntervalMESA(swapInterval);
-    else if(glXSwapIntervalSGI)
-        glXSwapIntervalSGI(swapInterval);
+    if (_glXSwapIntervalEXT)
+        _glXSwapIntervalEXT(display, window, swapInterval);
+    else if(_glXSwapIntervalMESA)
+        _glXSwapIntervalMESA(swapInterval);
+    else if(_glXSwapIntervalSGI)
+        _glXSwapIntervalSGI(swapInterval);
 }

--- a/modules/gl/native/linux/glx/gl-linux-glx.h
+++ b/modules/gl/native/linux/glx/gl-linux-glx.h
@@ -14,10 +14,10 @@ typedef GLXContext (*glXCreateContextAttribsARBPtr)(Display*, GLXFBConfig, GLXCo
 typedef GLXContext (*glXSwapIntervalEXTPtr)(Display*, GLXDrawable, const int);
 typedef GLXContext (*glXSwapIntervalMESAPtr)(const int);
 
-extern glXCreateContextAttribsARBPtr glXCreateContextAttribsARB;
-extern glXSwapIntervalEXTPtr         glXSwapIntervalEXT;
-extern glXSwapIntervalMESAPtr        glXSwapIntervalMESA;
-extern glXSwapIntervalMESAPtr        glXSwapIntervalSGI;
+extern glXCreateContextAttribsARBPtr _glXCreateContextAttribsARB;
+extern glXSwapIntervalEXTPtr         _glXSwapIntervalEXT;
+extern glXSwapIntervalMESAPtr        _glXSwapIntervalMESA;
+extern glXSwapIntervalMESAPtr        _glXSwapIntervalSGI;
 
 static void* _GetProcAddress(const char* name) {
     if(libGL == NULL){

--- a/modules/gl/native/macos/gl-macos-context.mm
+++ b/modules/gl/native/macos/gl-macos-context.mm
@@ -1,7 +1,7 @@
 #import "gl-macos.h"
 
 glGetIntegervPtr _glGetIntegerv;
-glGetStringiPtr _glGetStringi;
+glGetStringiPtr glGetStringi;
 
 static void getContextDetailsCGL(GLDetails* details, CGLContextObj context){
     CGLContextObj oldContext = CGLGetCurrentContext();
@@ -14,7 +14,7 @@ static void getContextDetailsCGL(GLDetails* details, CGLContextObj context){
 
 jni_macos_context(void, nInitFunctions)(JNIEnv* env, jobject) {
     _glGetIntegerv = (glGetIntegervPtr) a_GetProcAddress("_glGetIntegerv");
-    _glGetStringi = (glGetStringiPtr) a_GetProcAddress("_glGetStringi");
+    glGetStringi = (glGetStringiPtr) a_GetProcAddress("glGetStringi");
 }
 
 jni_macos_context(jlongArray, nCreateContext)(JNIEnv* env, jobject,

--- a/modules/gl/native/macos/gl-macos-context.mm
+++ b/modules/gl/native/macos/gl-macos-context.mm
@@ -1,7 +1,7 @@
 #import "gl-macos.h"
 
-glGetIntegervPtr glGetIntegerv;
-glGetStringiPtr glGetStringi;
+glGetIntegervPtr _glGetIntegerv;
+glGetStringiPtr _glGetStringi;
 
 static void getContextDetailsCGL(GLDetails* details, CGLContextObj context){
     CGLContextObj oldContext = CGLGetCurrentContext();
@@ -13,8 +13,8 @@ static void getContextDetailsCGL(GLDetails* details, CGLContextObj context){
 
 
 jni_macos_context(void, nInitFunctions)(JNIEnv* env, jobject) {
-    glGetIntegerv = (glGetIntegervPtr) a_GetProcAddress("glGetIntegerv");
-    glGetStringi = (glGetStringiPtr) a_GetProcAddress("glGetStringi");
+    _glGetIntegerv = (glGetIntegervPtr) a_GetProcAddress("_glGetIntegerv");
+    _glGetStringi = (glGetStringiPtr) a_GetProcAddress("_glGetStringi");
 }
 
 jni_macos_context(jlongArray, nCreateContext)(JNIEnv* env, jobject,

--- a/modules/gl/native/shared/gl-shared-context.cpp
+++ b/modules/gl/native/shared/gl-shared-context.cpp
@@ -8,7 +8,7 @@ jni_context(jobjectArray, nGetExtensions)(JNIEnv* env, jobject) {
     jobjectArray extensions = env->NewObjectArray(extCount, env->FindClass("java/lang/String"), NULL);
 
     for(int i = 0; i < extCount; i++){
-        const char* ext = (const char*)_glGetStringi(GL_EXTENSIONS, i);
+        const char* ext = (const char*)glGetStringi(GL_EXTENSIONS, i);
         env->SetObjectArrayElement(extensions, i, env->NewStringUTF(ext));
     }
     return extensions;

--- a/modules/gl/native/shared/gl-shared-context.cpp
+++ b/modules/gl/native/shared/gl-shared-context.cpp
@@ -3,12 +3,12 @@
 
 jni_context(jobjectArray, nGetExtensions)(JNIEnv* env, jobject) {
     GLint extCount = 0;
-    glGetIntegerv(GL_NUM_EXTENSIONS, &extCount);
+    _glGetIntegerv(GL_NUM_EXTENSIONS, &extCount);
 
     jobjectArray extensions = env->NewObjectArray(extCount, env->FindClass("java/lang/String"), NULL);
 
     for(int i = 0; i < extCount; i++){
-        const char* ext = (const char*)glGetStringi(GL_EXTENSIONS, i);
+        const char* ext = (const char*)_glGetStringi(GL_EXTENSIONS, i);
         env->SetObjectArrayElement(extensions, i, env->NewStringUTF(ext));
     }
     return extensions;

--- a/modules/gl/native/shared/gl-shared.h
+++ b/modules/gl/native/shared/gl-shared.h
@@ -39,9 +39,9 @@ typedef void (*glGetIntegervPtr)(GLenum pname, GLint* data);
 typedef const GLubyte* (*glGetStringiPtr)(GLenum name, GLuint index);
 typedef void (*glDebugMessageCallbackARBPtr)(GLDEBUGPROCARB callback, const void *userParam);
 
-extern glGetIntegervPtr glGetIntegerv;
-extern glGetStringiPtr glGetStringi;
-extern glDebugMessageCallbackARBPtr glDebugMessageCallbackARB;
+extern glGetIntegervPtr _glGetIntegerv;
+extern glGetStringiPtr _glGetStringi;
+extern glDebugMessageCallbackARBPtr _glDebugMessageCallbackARB;
 
 struct GLDetails {
     GLint major;
@@ -55,10 +55,10 @@ struct GLDetails {
 static void getContextDetails(GLDetails* details){
     GLint profileMask = 0;
 
-    glGetIntegerv(GL_MAJOR_VERSION, &details->major);
-    glGetIntegerv(GL_MINOR_VERSION, &details->minor);
-    glGetIntegerv(GL_CONTEXT_FLAGS, &details->flags);
-    glGetIntegerv(GL_CONTEXT_PROFILE_MASK, &profileMask);
+    _glGetIntegerv(GL_MAJOR_VERSION, &details->major);
+    _glGetIntegerv(GL_MINOR_VERSION, &details->minor);
+    _glGetIntegerv(GL_CONTEXT_FLAGS, &details->flags);
+    _glGetIntegerv(GL_CONTEXT_PROFILE_MASK, &profileMask);
 
     details->isCore = profileMask == GL_CONTEXT_CORE_PROFILE_BIT;
     details->debug = (details->flags & GL_CONTEXT_FLAG_DEBUG_BIT) != 0;
@@ -82,13 +82,13 @@ static void callbackFunction(GLenum source, GLenum type, GLuint id, GLenum sever
 }
 
 static void bindDefaultDebugFunction(JNIEnv* env, jclass callbackClass, const void* handle) {
-    if(glDebugMessageCallbackARB == NULL)
+    if(_glDebugMessageCallbackARB == NULL)
         return;
     if(jvm == NULL){
         env->GetJavaVM(&jvm);
         debugCallbackClass = (jclass)env->NewGlobalRef(callbackClass);
     }
-    glDebugMessageCallbackARB(&callbackFunction, handle);
+    _glDebugMessageCallbackARB(&callbackFunction, handle);
 }
 
 #endif

--- a/modules/gl/native/shared/gl-shared.h
+++ b/modules/gl/native/shared/gl-shared.h
@@ -40,7 +40,7 @@ typedef const GLubyte* (*glGetStringiPtr)(GLenum name, GLuint index);
 typedef void (*glDebugMessageCallbackARBPtr)(GLDEBUGPROCARB callback, const void *userParam);
 
 extern glGetIntegervPtr _glGetIntegerv;
-extern glGetStringiPtr _glGetStringi;
+extern glGetStringiPtr glGetStringi;
 extern glDebugMessageCallbackARBPtr _glDebugMessageCallbackARB;
 
 struct GLDetails {

--- a/modules/gl/native/win/gl-win-context.cpp
+++ b/modules/gl/native/win/gl-win-context.cpp
@@ -12,7 +12,7 @@ wglCreateContextAttribsARBPtr       wglCreateContextAttribsARB;
 wglSwapIntervalEXTPtr               wglSwapIntervalEXT;
 
 glGetIntegervPtr _glGetIntegerv;
-glGetStringiPtr _glGetStringi;
+glGetStringiPtr glGetStringi;
 glDebugMessageCallbackARBPtr _glDebugMessageCallbackARB;
 
 
@@ -75,7 +75,7 @@ jni_win_context(void, nInitFunctions)(JNIEnv* env, jobject) {
         wglCreateContextAttribsARB = (wglCreateContextAttribsARBPtr) _GetProcAddress("wglCreateContextAttribsARB");
         wglSwapIntervalEXT = (wglSwapIntervalEXTPtr) _GetProcAddress("wglSwapIntervalEXT");
         _glGetIntegerv = (glGetIntegervPtr) _GetProcAddress("_glGetIntegerv");
-        _glGetStringi = (glGetStringiPtr) _GetProcAddress("_glGetStringi");
+        glGetStringi = (glGetStringiPtr) _GetProcAddress("glGetStringi");
         _glDebugMessageCallbackARB = (glDebugMessageCallbackARBPtr) _GetProcAddress("_glDebugMessageCallbackARB");
 
         // Destroy dummy context

--- a/modules/gl/native/win/gl-win-context.cpp
+++ b/modules/gl/native/win/gl-win-context.cpp
@@ -11,9 +11,9 @@ wglChoosePixelFormatARBPtr          wglChoosePixelFormatARB;
 wglCreateContextAttribsARBPtr       wglCreateContextAttribsARB;
 wglSwapIntervalEXTPtr               wglSwapIntervalEXT;
 
-glGetIntegervPtr glGetIntegerv;
-glGetStringiPtr glGetStringi;
-glDebugMessageCallbackARBPtr glDebugMessageCallbackARB;
+glGetIntegervPtr _glGetIntegerv;
+glGetStringiPtr _glGetStringi;
+glDebugMessageCallbackARBPtr _glDebugMessageCallbackARB;
 
 
 static void getContextDetailsWGL(GLDetails* details, HGLRC rc, HDC dc){
@@ -74,9 +74,9 @@ jni_win_context(void, nInitFunctions)(JNIEnv* env, jobject) {
         wglChoosePixelFormatARB = (wglChoosePixelFormatARBPtr) _GetProcAddress("wglChoosePixelFormatARB");
         wglCreateContextAttribsARB = (wglCreateContextAttribsARBPtr) _GetProcAddress("wglCreateContextAttribsARB");
         wglSwapIntervalEXT = (wglSwapIntervalEXTPtr) _GetProcAddress("wglSwapIntervalEXT");
-        glGetIntegerv = (glGetIntegervPtr) _GetProcAddress("glGetIntegerv");
-        glGetStringi = (glGetStringiPtr) _GetProcAddress("glGetStringi");
-        glDebugMessageCallbackARB = (glDebugMessageCallbackARBPtr) _GetProcAddress("glDebugMessageCallbackARB");
+        _glGetIntegerv = (glGetIntegervPtr) _GetProcAddress("_glGetIntegerv");
+        _glGetStringi = (glGetStringiPtr) _GetProcAddress("_glGetStringi");
+        _glDebugMessageCallbackARB = (glDebugMessageCallbackARBPtr) _GetProcAddress("_glDebugMessageCallbackARB");
 
         // Destroy dummy context
         _wglMakeCurrent(oldDC, oldRC);


### PR DESCRIPTION
Issue: https://github.com/husker-dev/openglfx/issues/108

This pull request fixes a fatal crash (SIGSEGV) that occurs during OpenGL initialization via GLX on Linux. The issue is **consistently reproducible in Wayland-based environments**. It was tested on **Ubuntu (via WSL)** and **Fedora on real hardware**.

During OpenGL initialization, when loading function pointers via `_GetProcAddress` in `GLXContext.cpp`, the application crashes with SIGSEGV in `Java_com_huskerdev_grapl_gl_platforms_linux_glx_GLXContext_nInitFunctions`.

I am not fully certain about the exact root cause, as **I am not a C++ developer**, but based on debugging and observed behavior, the issue appears to be related to global C++ function pointer variables having the same names as the actual OpenGL/GLX functions. This likely causes a symbol name conflict during linking and results in an attempt to write to an invalid or read-only memory region.

The fix follows the same approach already used in the existing WGL (Win32) implementation in this project. Global OpenGL function pointer variables were renamed using a leading underscore (for example, `glGetIntegerv` → `_glGetIntegerv`) to avoid potential symbol name collisions. `_GetProcAddress` still looks up the original function names (e.g. `"glGetIntegerv"`), but the returned pointers are stored in the renamed variables. 

After local testing, the application now starts reliably under WSL and the crash no longer occurs.

**Before merging, it is strongly recommended to additionally test these changes on different Linux distributions and system configurations.**

