### PR TITLE
Resolve symbol collision causing crashes on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 /.gradle/
 /build/
 /.idea/
+
+# Gradle build outputs
+/modules/*/build/
+/modules/*/native/build/
+
+/plugins/*/.gradle/
+/plugins/*/build/

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2.3.13
+version=2.3.14
 
 kotlin.code.style=official
 

--- a/modules/gl/native/linux/egl/gl-linux-egl-context.cpp
+++ b/modules/gl/native/linux/egl/gl-linux-egl-context.cpp
@@ -16,9 +16,9 @@ eglDestroyContextPtr      eglDestroyContext;
 eglSwapBuffersPtr         eglSwapBuffers;
 eglSwapIntervalPtr        eglSwapInterval;
 
-glGetIntegervPtr          glGetIntegerv;
-glGetStringiPtr           glGetStringi;
-glDebugMessageCallbackARBPtr glDebugMessageCallbackARB;
+glGetIntegervPtr          _glGetIntegerv;
+glGetStringiPtr           _glGetStringi;
+glDebugMessageCallbackARBPtr _glDebugMessageCallbackARB;
 
 
 static void getContextDetailsEGL(GLDetails* details, EGLDisplay display, EGLSurface surfaceRead, EGLSurface surfaceWrite, EGLContext context){
@@ -55,9 +55,9 @@ jni_linux_egl_context(void, nInitFunctions)(JNIEnv* env, jobject) {
     eglSwapBuffers = (eglSwapBuffersPtr)eglGetProcAddress("eglSwapBuffers");
     eglSwapInterval = (eglSwapIntervalPtr)eglGetProcAddress("eglSwapInterval");
 
-    glDebugMessageCallbackARB = (glDebugMessageCallbackARBPtr)eglGetProcAddress("glDebugMessageCallbackARB");
-    glGetIntegerv = (glGetIntegervPtr)eglGetProcAddress("glGetIntegerv");
-    glGetStringi = (glGetStringiPtr)eglGetProcAddress("glGetStringi");
+    _glDebugMessageCallbackARB = (glDebugMessageCallbackARBPtr)eglGetProcAddress("glDebugMessageCallbackARB");
+    _glGetIntegerv = (glGetIntegervPtr)eglGetProcAddress("glGetIntegerv");
+    _glGetStringi = (glGetStringiPtr)eglGetProcAddress("glGetStringi");
 }
 
 jni_linux_egl_context(jlongArray, nCreateContext)(JNIEnv* env, jobject, jboolean isCore, jlong shareWith, jint majorVersion, jint minorVersion, jboolean debug) {

--- a/modules/gl/native/linux/glx/gl-linux-glx-context.cpp
+++ b/modules/gl/native/linux/glx/gl-linux-glx-context.cpp
@@ -23,9 +23,9 @@ jni_linux_glx_context(void, nInitFunctions)(JNIEnv* env, jobject) {
     glXSwapIntervalMESA = (glXSwapIntervalMESAPtr)_GetProcAddress("glXSwapIntervalMESA");
     glXSwapIntervalSGI = (glXSwapIntervalMESAPtr)_GetProcAddress("glXSwapIntervalSGI");
 
-    glDebugMessageCallbackARB = (glDebugMessageCallbackARBPtr)_GetProcAddress("glDebugMessageCallbackARB");
-    glGetIntegerv = (glGetIntegervPtr)_GetProcAddress("glGetIntegerv");
-    glGetStringi = (glGetStringiPtr)_GetProcAddress("glGetStringi");
+    _glDebugMessageCallbackARB = (glDebugMessageCallbackARBPtr)_GetProcAddress("glDebugMessageCallbackARB");
+    _glGetIntegerv = (glGetIntegervPtr)_GetProcAddress("glGetIntegerv");
+    _glGetStringi = (glGetStringiPtr)_GetProcAddress("glGetStringi");
 }
 
 jni_linux_glx_context(jlongArray, nCreateContext)(JNIEnv* env, jobject, jboolean isCore, jlong shareWith, jint majorVersion, jint minorVersion, jboolean debug) {

--- a/modules/gl/native/macos/gl-macos-context.mm
+++ b/modules/gl/native/macos/gl-macos-context.mm
@@ -1,7 +1,7 @@
 #import "gl-macos.h"
 
-glGetIntegervPtr glGetIntegerv;
-glGetStringiPtr glGetStringi;
+glGetIntegervPtr _glGetIntegerv;
+glGetStringiPtr _glGetStringi;
 
 static void getContextDetailsCGL(GLDetails* details, CGLContextObj context){
     CGLContextObj oldContext = CGLGetCurrentContext();
@@ -13,8 +13,8 @@ static void getContextDetailsCGL(GLDetails* details, CGLContextObj context){
 
 
 jni_macos_context(void, nInitFunctions)(JNIEnv* env, jobject) {
-    glGetIntegerv = (glGetIntegervPtr) a_GetProcAddress("glGetIntegerv");
-    glGetStringi = (glGetStringiPtr) a_GetProcAddress("glGetStringi");
+    _glGetIntegerv = (glGetIntegervPtr) a_GetProcAddress("glGetIntegerv");
+    _glGetStringi = (glGetStringiPtr) a_GetProcAddress("glGetStringi");
 }
 
 jni_macos_context(jlongArray, nCreateContext)(JNIEnv* env, jobject,

--- a/modules/gl/native/shared/gl-shared-context.cpp
+++ b/modules/gl/native/shared/gl-shared-context.cpp
@@ -3,12 +3,12 @@
 
 jni_context(jobjectArray, nGetExtensions)(JNIEnv* env, jobject) {
     GLint extCount = 0;
-    glGetIntegerv(GL_NUM_EXTENSIONS, &extCount);
+    _glGetIntegerv(GL_NUM_EXTENSIONS, &extCount);
 
     jobjectArray extensions = env->NewObjectArray(extCount, env->FindClass("java/lang/String"), NULL);
 
     for(int i = 0; i < extCount; i++){
-        const char* ext = (const char*)glGetStringi(GL_EXTENSIONS, i);
+        const char* ext = (const char*)_glGetStringi(GL_EXTENSIONS, i);
         env->SetObjectArrayElement(extensions, i, env->NewStringUTF(ext));
     }
     return extensions;

--- a/modules/gl/native/shared/gl-shared.h
+++ b/modules/gl/native/shared/gl-shared.h
@@ -39,9 +39,9 @@ typedef void (*glGetIntegervPtr)(GLenum pname, GLint* data);
 typedef const GLubyte* (*glGetStringiPtr)(GLenum name, GLuint index);
 typedef void (*glDebugMessageCallbackARBPtr)(GLDEBUGPROCARB callback, const void *userParam);
 
-extern glGetIntegervPtr glGetIntegerv;
-extern glGetStringiPtr glGetStringi;
-extern glDebugMessageCallbackARBPtr glDebugMessageCallbackARB;
+extern glGetIntegervPtr _glGetIntegerv;
+extern glGetStringiPtr _glGetStringi;
+extern glDebugMessageCallbackARBPtr _glDebugMessageCallbackARB;
 
 struct GLDetails {
     GLint major;
@@ -55,10 +55,10 @@ struct GLDetails {
 static void getContextDetails(GLDetails* details){
     GLint profileMask = 0;
 
-    glGetIntegerv(GL_MAJOR_VERSION, &details->major);
-    glGetIntegerv(GL_MINOR_VERSION, &details->minor);
-    glGetIntegerv(GL_CONTEXT_FLAGS, &details->flags);
-    glGetIntegerv(GL_CONTEXT_PROFILE_MASK, &profileMask);
+    _glGetIntegerv(GL_MAJOR_VERSION, &details->major);
+    _glGetIntegerv(GL_MINOR_VERSION, &details->minor);
+    _glGetIntegerv(GL_CONTEXT_FLAGS, &details->flags);
+    _glGetIntegerv(GL_CONTEXT_PROFILE_MASK, &profileMask);
 
     details->isCore = profileMask == GL_CONTEXT_CORE_PROFILE_BIT;
     details->debug = (details->flags & GL_CONTEXT_FLAG_DEBUG_BIT) != 0;
@@ -82,13 +82,13 @@ static void callbackFunction(GLenum source, GLenum type, GLuint id, GLenum sever
 }
 
 static void bindDefaultDebugFunction(JNIEnv* env, jclass callbackClass, const void* handle) {
-    if(glDebugMessageCallbackARB == NULL)
+    if(_glDebugMessageCallbackARB == NULL)
         return;
     if(jvm == NULL){
         env->GetJavaVM(&jvm);
         debugCallbackClass = (jclass)env->NewGlobalRef(callbackClass);
     }
-    glDebugMessageCallbackARB(&callbackFunction, handle);
+    _glDebugMessageCallbackARB(&callbackFunction, handle);
 }
 
 #endif

--- a/modules/gl/native/win/gl-win-context.cpp
+++ b/modules/gl/native/win/gl-win-context.cpp
@@ -11,9 +11,9 @@ wglChoosePixelFormatARBPtr          wglChoosePixelFormatARB;
 wglCreateContextAttribsARBPtr       wglCreateContextAttribsARB;
 wglSwapIntervalEXTPtr               wglSwapIntervalEXT;
 
-glGetIntegervPtr glGetIntegerv;
-glGetStringiPtr glGetStringi;
-glDebugMessageCallbackARBPtr glDebugMessageCallbackARB;
+glGetIntegervPtr _glGetIntegerv;
+glGetStringiPtr _glGetStringi;
+glDebugMessageCallbackARBPtr _glDebugMessageCallbackARB;
 
 
 static void getContextDetailsWGL(GLDetails* details, HGLRC rc, HDC dc){
@@ -74,9 +74,9 @@ jni_win_context(void, nInitFunctions)(JNIEnv* env, jobject) {
         wglChoosePixelFormatARB = (wglChoosePixelFormatARBPtr) _GetProcAddress("wglChoosePixelFormatARB");
         wglCreateContextAttribsARB = (wglCreateContextAttribsARBPtr) _GetProcAddress("wglCreateContextAttribsARB");
         wglSwapIntervalEXT = (wglSwapIntervalEXTPtr) _GetProcAddress("wglSwapIntervalEXT");
-        glGetIntegerv = (glGetIntegervPtr) _GetProcAddress("glGetIntegerv");
-        glGetStringi = (glGetStringiPtr) _GetProcAddress("glGetStringi");
-        glDebugMessageCallbackARB = (glDebugMessageCallbackARBPtr) _GetProcAddress("glDebugMessageCallbackARB");
+        _glGetIntegerv = (glGetIntegervPtr) _GetProcAddress("glGetIntegerv");
+        _glGetStringi = (glGetStringiPtr) _GetProcAddress("glGetStringi");
+        _glDebugMessageCallbackARB = (glDebugMessageCallbackARBPtr) _GetProcAddress("glDebugMessageCallbackARB");
 
         // Destroy dummy context
         _wglMakeCurrent(oldDC, oldRC);


### PR DESCRIPTION
_Сlosed the previous PR because I got confused about what I was testing, what wasn't there, and generally created it incorrectly from the main branch._

This PR fixes a critical SIGSEGV crash on Linux. The issue was caused by a symbol collision where global pointer variables shared the exact same names as system OpenGL functions (e.g., glGetIntegerv). The Linux dynamic linker would resolve to our variable instead of the real function, causing a crash.